### PR TITLE
accept "sig" use of JWK for verifying

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -181,10 +181,6 @@ func VerifyWithJWK(buf []byte, keyset *jwk.Set) ([]byte, error) {
 	}
 
 	for _, key := range keyset.Keys {
-		if u := key.Use(); u != "" && u != "enc" {
-			continue
-		}
-
 		keyval, err := key.Materialize()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
As mentioned in https://github.com/lestrrat/go-jwx/issues/3, I thought `VerifyWithJWK` method should accept `sig` use value to verify JWS.
How do you think about it?