### PR TITLE
Add key_ops support for jwk/Key (g|s)etter interface

### DIFF
--- a/jwk/header.go
+++ b/jwk/header.go
@@ -14,6 +14,8 @@ func (h *EssentialHeader) Get(key string) (interface{}, error) {
 		return h.Algorithm, nil
 	case "kid":
 		return h.KeyID, nil
+	case "key_ops":
+		return h.KeyOps, nil
 	case "kty":
 		return h.KeyType, nil
 	case "use":
@@ -50,6 +52,13 @@ func (h *EssentialHeader) Set(key string, value interface{}) error {
 			return ErrInvalidHeaderValue
 		}
 		h.KeyID = v
+		return nil
+	case "key_ops":
+		v, ok := value.([]KeyOperation)
+		if !ok {
+			return ErrInvalidHeaderValue
+		}
+		h.KeyOps = v
 		return nil
 	case "kty":
 		switch value.(type) {

--- a/jwk/header_test.go
+++ b/jwk/header_test.go
@@ -13,6 +13,7 @@ func TestHeader(t *testing.T) {
 	values := map[string]interface{}{
 		"kid":     "helloworld01",
 		"kty":     jwa.RSA,
+		"key_ops": []KeyOperation{KeyOpSign},
 		"use":     "sig",
 		"x5t":     "thumbprint",
 		"x5t#256": "thumbprint256",
@@ -32,6 +33,11 @@ func TestHeader(t *testing.T) {
 		}
 
 		if !assert.Equal(t, v, got, "values match '%s'", k) {
+			return
+		}
+
+		err = h.Set(k, v)
+		if !assert.NoError(t, err, "Set works for '%s'", k) {
 			return
 		}
 	}


### PR DESCRIPTION
Value of key_ops of accessor was added because it was not implemented.
If the dare of unsupported, please close this PR.