### PR TITLE
Initialize the EssentialHeader of ECDSA JWKs.

### DIFF
--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -26,7 +26,8 @@ func i2osp(v *big.Int, n int) []byte {
 // NewEcdsaPublicKey creates a new JWK from a EC-DSA public key
 func NewEcdsaPublicKey(pk *ecdsa.PublicKey) *EcdsaPublicKey {
 	pubkey := &EcdsaPublicKey{
-		Curve: jwa.EllipticCurveAlgorithm(pk.Params().Name),
+		EssentialHeader: &EssentialHeader{KeyType: jwa.EC},
+		Curve:           jwa.EllipticCurveAlgorithm(pk.Params().Name),
 	}
 	n := pk.Params().BitSize / 8
 	pubkey.X.SetBytes(i2osp(pk.X, n))

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -90,26 +90,27 @@ func TestParse_EcdsaPrivateKey(t *testing.T) {
 func TestParse_EcdsaInitKey(t *testing.T) {
 	// Generate an ECDSA P-256 test key.
 	ecPrk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	assert.NoError(t, err, "Failed to generate EC P-256 key")
-
+	if !assert.NoError(t, err, "Failed to generate EC P-256 key") {
+		return
+	}
 	// Test initialization of a private EC JWK.
 	prk := NewEcdsaPrivateKey(ecPrk)
 	err = prk.Set("kid", "MyKey")
-	assert.NoError(t, err, "Failed to set private key ID")
-	assert.Equal(t, prk.KeyType, jwa.EC, "Private key type mismatch")
-	assert.Equal(t, prk.Curve, jwa.P256, "Private key curve mismatch")
-	assert.Equal(t, prk.X.Bytes(), ecPrk.X.Bytes(), "Private key X mismatch")
-	assert.Equal(t, prk.Y.Bytes(), ecPrk.Y.Bytes(), "Private key Y mismatch")
-	assert.Equal(t, prk.D.Bytes(), ecPrk.D.Bytes(), "Private key D mismatch")
-	assert.Equal(t, prk.KeyID, "MyKey", "Private key ID mismatch")
+	assert.NoError(t, err, "Set private key ID success")
+	assert.Equal(t, prk.KeyType, jwa.EC, "Private key type match")
+	assert.Equal(t, prk.Curve, jwa.P256, "Private key curve match")
+	assert.Equal(t, prk.X.Bytes(), ecPrk.X.Bytes(), "Private key X match")
+	assert.Equal(t, prk.Y.Bytes(), ecPrk.Y.Bytes(), "Private key Y match")
+	assert.Equal(t, prk.D.Bytes(), ecPrk.D.Bytes(), "Private key D match")
+	assert.Equal(t, prk.KeyID, "MyKey", "Private key ID match")
 
 	// Test initialization of a public EC JWK.
 	puk := NewEcdsaPublicKey(&ecPrk.PublicKey)
 	err = puk.Set("kid", "MyKey")
-	assert.NoError(t, err, "Failed to set public key ID")
-	assert.Equal(t, puk.KeyType, jwa.EC, "Public key type mismatch")
-	assert.Equal(t, puk.Curve, jwa.P256, "Public key curve mismatch")
-	assert.Equal(t, puk.X.Bytes(), ecPrk.X.Bytes(), "Public key X mismatch")
-	assert.Equal(t, puk.Y.Bytes(), ecPrk.Y.Bytes(), "Public key Y mismatch")
-	assert.Equal(t, prk.KeyID, "MyKey", "Public key ID mismatch")
+	assert.NoError(t, err, " Set public key ID success")
+	assert.Equal(t, puk.KeyType, jwa.EC, "Public key type match")
+	assert.Equal(t, puk.Curve, jwa.P256, "Public key curve match")
+	assert.Equal(t, puk.X.Bytes(), ecPrk.X.Bytes(), "Public key X match")
+	assert.Equal(t, puk.Y.Bytes(), ecPrk.Y.Bytes(), "Public key Y march")
+	assert.Equal(t, prk.KeyID, "MyKey", "Public key ID match")
 }


### PR DESCRIPTION
The jwk.NewEcdsaPublicKey and jwk.NewEcdsaPrivateKey functions
are not initializing the EssentialHeader of the EcdsaPublicKey struct
which means they do not have an initialized KeyType (jwa.EC) and
attempts to set header parameters with Set() cause a panic. This
initialization is done correctly for RSA keys.

This commit fixes the initializion of the EssentialHeader for JWK
ECDSA keys and sets their KeyType parameter to jwa.EC. A unit test
is also implemented to verify correct behavior.