### PR TITLE
Fix JWT parsing of JWT NotBefore (nbf) header parameter.

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -76,7 +76,7 @@ func (c *EssentialClaims) Construct(m map[string]interface{}) error {
 	c.IssuedAt, _ = r.GetInt64("iat")
 	c.Issuer, _ = r.GetString("iss")
 	c.JwtID, _ = r.GetString("jti")
-	if v, err := r.GetString("nbf"); err != nil {
+	if v, err := r.GetString("nbf"); err == nil {
 		if v != "" {
 			t, err := time.Parse(numericDateFmt, v)
 			if err != nil {
@@ -169,7 +169,7 @@ func (c *ClaimSet) Set(key string, value interface{}) error {
 		case *NumericDate:
 			c.NotBefore = value.(*NumericDate)
 		case time.Time:
-			c.NotBefore = &NumericDate{value.(time.Time)}
+			c.NotBefore = &NumericDate{value.(time.Time).UTC().Round(time.Second)}
 		default:
 			return ErrInvalidValue
 		}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -10,9 +10,13 @@ import (
 
 func TestClaimSet(t *testing.T) {
 	c1 := NewClaimSet()
-	c1.Set("nonce", "AbCdEfG")
+	c1.Set("jti", "AbCdEfG")
 	c1.Set("sub", "foobar@example.com")
-	c1.Set("iat", time.Now().Unix())
+	now := time.Now()
+	c1.Set("iat", now)
+	c1.Set("nbf", now.Add(5*time.Second))
+	c1.Set("exp", now.Add(10*time.Second))
+	c1.Set("custom", "MyValue")
 
 	jsonbuf1, err := json.MarshalIndent(c1, "", "  ")
 	if !assert.NoError(t, err, "JSON marshal should succeed") {


### PR DESCRIPTION
The Construct() method for a JWT EssentialClaim has an incorrect
error check comparison (simply a != instead of an ==) for the
GetString() of the "nbf" parameter. This causes the nbf value to
not be parsed when parsing a JWT. The subsequent check for empty
value prevented the error from being exposed. This fix corrects
the equality condition.

The Set() method for nbf has also been corrected to round the
time.Time argument to the nearest second to match the granulity
of the time format string in the JWT JSON. This rounding allows
the marshal/unmarshal roundtrip to JSON to be lossless. Without
it the unit test comparison fails because the initial time value
(from time.Now) has a nanoseconds component that gets stripped
off and lost when encoding to JSON. The time value is also converted
to UTC to match the timezone of the encoded nbf string.

The unit test was also updated to verify this fix by adding the
nbf parameter to the test ClaimSet. I also correct the nonce
parameter to be jti and added a private claim for a little more
coverage.