### PR TITLE
Fix constructEssentialHeader: key_ops

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -115,7 +115,7 @@ func constructEssentialHeader(m map[string]interface{}) (*EssentialHeader, error
 	e.KeyUsage, _ = r.GetString("use")
 
 	// https://tools.ietf.org/html/rfc7517#section-4.3
-	if v, err := r.GetStringSlice("key_ops"); err != nil {
+	if v, err := r.GetStringSlice("key_ops"); err == nil {
 		if len(v) > 0 {
 			e.KeyOps = make([]KeyOperation, len(v))
 			for i, x := range v {

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -252,3 +252,34 @@ func TestAppendix_B(t *testing.T) {
 		}
 	}
 }
+
+func TestConstructEssentialHeader(t *testing.T) {
+	var jwksrc = []byte(`{"keys":
+       [
+        {"kty":"oct",
+         "use":"sig",
+         "key_ops": ["sign","verify"],
+         "alg": "HS256",
+         "k":"test",
+         "kid":"test"}
+       ]
+     }`)
+
+	set, err := Parse(jwksrc)
+	if !assert.NoError(t, err, "Parse should succeed") {
+		return
+	}
+	{
+		key, ok := set.Keys[0].(*SymmetricKey)
+		if !assert.True(t, ok, "set.Keys[0] should be a SymmetricKey") {
+			return
+		}
+		ops, err := key.Get("key_ops")
+		if !assert.NoError(t, err, "key.Get(key_ops) should succeed") {
+			return
+		}
+		if !assert.Equal(t, ops, []KeyOperation{KeyOpSign, KeyOpVerify}, "key.KeyOps should be equal") {
+			return
+		}
+	}
+}


### PR DESCRIPTION
Since failed to parse of key_ops header, it has been fixed.