### PR TITLE
Topic/gh 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 sudo: false
 go:
-    - 1.5
+    - 1.7.x
     - tip

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -164,10 +164,6 @@ func Verify(buf []byte, alg jwa.SignatureAlgorithm, key interface{}) ([]byte, er
 		return nil, err
 	}
 
-	// We need to verify essential claims
-	if err := verifyEssentialClaims(msg); err != nil {
-		return nil, errVerifyFailed
-	}
 	return msg.Payload.Bytes(), nil
 }
 
@@ -234,15 +230,6 @@ func verifyMessageWithJWK(m *Message, key jwk.Key) error {
 	}
 
 	return nil
-}
-
-func verifyEssentialClaims(m *Message) error {
-
-	if debug.Enabled {
-		debug.Printf("%#v\n", m)
-	}
-	return nil
-
 }
 
 // VerifyWithJWK verifies the JWS message using the specified JWK

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -26,8 +26,7 @@ func (f clockFunc) Now() time.Time {
 	return f()
 }
 
-// Verify takes an optional VerifyContext parameter, which specifies,
-// for example, what "time" we should use to check against among other things
+// Verify makes sure that the essential claims stand
 func (c *ClaimSet) Verify(options ...VerifyOption) error {
 	var clock Clock = clockFunc(time.Now)
 	for _, o := range options {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -3,52 +3,11 @@ package jwt
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/lestrrat/go-jwx/internal/emap"
 )
-
-const clockKey = "clock"
-
-type VerifyOption interface {
-	Name() string
-	Value() interface{}
-}
-
-type Clock interface {
-	Now() time.Time
-}
-type clockFunc func() time.Time
-
-func (f clockFunc) Now() time.Time {
-	return f()
-}
-
-// Verify makes sure that the essential claims stand
-func (c *ClaimSet) Verify(options ...VerifyOption) error {
-	var clock Clock = clockFunc(time.Now)
-	for _, o := range options {
-		switch o.Name() {
-		case clockKey:
-			clock = o.Value().(Clock)
-		}
-	}
-	// iss
-	// sub
-	// aud
-	// exp
-	// nbf
-	// iat
-	// jti
-	if t := c.NotBefore; t != nil {
-		if clock.Now().Before(t.Time) {
-			return errors.New(`nbf not satisfied`)
-		}
-	}
-	return nil
-}
 
 // MarshalJSON generates JSON representation of this instant
 func (n NumericDate) MarshalJSON() ([]byte, error) {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -3,11 +3,53 @@ package jwt
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/lestrrat/go-jwx/internal/emap"
 )
+
+const clockKey = "clock"
+
+type VerifyOption interface {
+	Name() string
+	Value() interface{}
+}
+
+type Clock interface {
+	Now() time.Time
+}
+type clockFunc func() time.Time
+
+func (f clockFunc) Now() time.Time {
+	return f()
+}
+
+// Verify takes an optional VerifyContext parameter, which specifies,
+// for example, what "time" we should use to check against among other things
+func (c *ClaimSet) Verify(options ...VerifyOption) error {
+	var clock Clock = clockFunc(time.Now)
+	for _, o := range options {
+		switch o.Name() {
+		case clockKey:
+			clock = o.Value().(Clock)
+		}
+	}
+	// iss
+	// sub
+	// aud
+	// exp
+	// nbf
+	// iat
+	// jti
+	if t := c.NotBefore; t != nil {
+		if clock.Now().Before(t.Time) {
+			return errors.New(`nbf not satisfied`)
+		}
+	}
+	return nil
+}
 
 // MarshalJSON generates JSON representation of this instant
 func (n NumericDate) MarshalJSON() ([]byte, error) {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -41,9 +41,23 @@ func TestClaimSet(t *testing.T) {
 	}
 }
 
+func TestGHIssue10_iss(t *testing.T) {
+	c := jwt.NewClaimSet()
+	c.Issuer = "github.com/lestrrat/go-jwx"
+
+	// This should succeed, because WithIssuer is not provided in the
+	// optinal parameters
+	if !assert.NoError(t, c.Verify(), "claimset.Verify should succeed") {
+		return
+	}
+
+	if !assert.Error(t, c.Verify(jwt.WithIssuer("poop")), "claimset.Verify should fail") {
+		return
+	}
+}
+
 func TestGHIssue10_nbf(t *testing.T) {
 	c := jwt.NewClaimSet()
-	c.Set("sub", "jwt-essential-claim-verification")
 
 	// NotBefore is set to future date
 	tm := time.Now().Add(72 * time.Hour)
@@ -69,7 +83,6 @@ func TestGHIssue10_nbf(t *testing.T) {
 
 func TestGHIssue10_exp(t *testing.T) {
 	c := jwt.NewClaimSet()
-	c.Set("sub", "jwt-essential-claim-verification")
 
 	// issuedat = 1 Hr before current time
 	tm := time.Now()

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -51,7 +51,58 @@ func TestGHIssue10_iss(t *testing.T) {
 		return
 	}
 
+	// This should succeed, because WithIssuer is provided with same value
+	if !assert.NoError(t, c.Verify(jwt.WithIssuer(c.Issuer)), "claimset.Verify should succeed") {
+		return
+	}
+
 	if !assert.Error(t, c.Verify(jwt.WithIssuer("poop")), "claimset.Verify should fail") {
+		return
+	}
+}
+
+func TestGHIssue10_aud(t *testing.T) {
+	c := jwt.NewClaimSet()
+	c.Audience = []string{
+		"foo",
+		"bar",
+		"baz",
+	}
+
+	// This should succeed, because WithAudience is not provided in the
+	// optinal parameters
+	if !assert.NoError(t, c.Verify(), "claimset.Verify should succeed") {
+		return
+	}
+
+	// This should succeed, because WithAudience is provided, and its
+	// value matches one of the audience values
+	if !assert.NoError(t, c.Verify(jwt.WithAudience("baz")), "claimset.Verify should succeed") {
+		return
+	}
+
+	if !assert.Error(t, c.Verify(jwt.WithAudience("poop")), "claimset.Verify should fail") {
+		return
+	}
+}
+
+func TestGHIssue10_sub(t *testing.T) {
+	c := jwt.NewClaimSet()
+	c.Subject = "github.com/lestrrat/go-jwx"
+
+	// This should succeed, because WithSubject is not provided in the
+	// optinal parameters
+	if !assert.NoError(t, c.Verify(), "claimset.Verify should succeed") {
+		return
+	}
+
+	// This should succeed, because WithSubject is provided with same value
+	if !assert.NoError(t, c.Verify(jwt.WithSubject(c.Subject)), "claimset.Verify should succeed") {
+		return
+	}
+
+
+	if !assert.Error(t, c.Verify(jwt.WithSubject("poop")), "claimset.Verify should fail") {
 		return
 	}
 }

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1,14 +1,10 @@
 package jwt_test
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/lestrrat/go-jwx/jwa"
-	"github.com/lestrrat/go-jwx/jws"
 	"github.com/lestrrat/go-jwx/jwt"
 	"github.com/stretchr/testify/assert"
 )
@@ -45,13 +41,6 @@ func TestClaimSet(t *testing.T) {
 	}
 }
 
-/*
-	// issuedat = 1 Hr before current time
-	c.IssuedAt = time.Now().Unix() - 3600
-
-	// valid for 2 minutes only from IssuedAt
-	c.Expiration = c.IssuedAt + 120
-*/
 func TestGHIssue10_nbf(t *testing.T) {
 	c := jwt.NewClaimSet()
 	c.Set("sub", "jwt-essential-claim-verification")
@@ -60,55 +49,50 @@ func TestGHIssue10_nbf(t *testing.T) {
 	tm := time.Now().Add(72 * time.Hour)
 	c.NotBefore = &jwt.NumericDate{tm}
 
-	//get json
-	buf, err := json.MarshalIndent(c, "", "  ")
-	if !assert.NoError(t, err, `generating JSON should succeed`) {
-		return
-	}
-
-	// generte rsa key
-	rsakey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if !assert.NoError(t, err, `generating private key should succeed`) {
-		return
-	}
-
-	// sign payload
-	sbuf, err := jws.Sign(buf, jwa.RS256, rsakey)
-	if !assert.NoError(t, err, `jws.Sign should succeed`) {
-		return
-	}
-
-	// Verify signature and grab payload
-	verified, err := jws.Verify(sbuf, jwa.RS256, &rsakey.PublicKey)
-	if !assert.NoError(t, err, `jws.Verify should succeed`) {
-
-	}
-
-	cs := jwt.NewClaimSet()
-	if err = cs.UnmarshalJSON(verified); err != nil {
-		t.Logf("failed to get claimset: %s", err)
-		return
-	}
-
 	// This should fail, because nbf is the future
-	if !assert.Error(t, cs.Verify(), "claimset.Verify should fail") {
-		t.Logf("JWS verified even expired!!!")
-		// print Essential claims
-		t.Logf("IssuedAt: %v", time.Unix(cs.IssuedAt, 0))
-		t.Logf("Expiration: %v", time.Unix(cs.Expiration, 0))
-		t.Logf("NotBefore: %v", cs.NotBefore)
+	if !assert.Error(t, c.Verify(), "claimset.Verify should fail") {
 		return
 	}
 
 	// This should succeed, because we have given reaaaaaaly big skew
 	// that is well enough to get us accepted
-	if !assert.NoError(t, cs.Verify(jwt.WithAcceptableSkew(73*time.Hour)), "claimset.Verify should succeed") {
+	if !assert.NoError(t, c.Verify(jwt.WithAcceptableSkew(73*time.Hour)), "claimset.Verify should succeed") {
 		return
 	}
 
 	// This should succeed, because we have given a time
 	// that is well enough into the future
-	if !assert.NoError(t, cs.Verify(jwt.WithClock(jwt.ClockFunc(func() time.Time { return tm.Add(time.Hour) }))), "claimset.Verify should succeed") {
+	if !assert.NoError(t, c.Verify(jwt.WithClock(jwt.ClockFunc(func() time.Time { return tm.Add(time.Hour) }))), "claimset.Verify should succeed") {
 		return
 	}
 }
+
+func TestGHIssue10_exp(t *testing.T) {
+	c := jwt.NewClaimSet()
+	c.Set("sub", "jwt-essential-claim-verification")
+
+	// issuedat = 1 Hr before current time
+	tm := time.Now()
+	c.IssuedAt = tm.Unix() - 3600
+
+	// valid for 2 minutes only from IssuedAt
+	c.Expiration = c.IssuedAt + 120
+
+	// This should fail, because exp is set in the past
+	if !assert.Error(t, c.Verify(), "claimset.Verify should fail") {
+		return
+	}
+
+	// This should succeed, because we have given big skew
+	// that is well enough to get us accepted
+	if !assert.NoError(t, c.Verify(jwt.WithAcceptableSkew(time.Hour)), "claimset.Verify should succeed") {
+		return
+	}
+
+	// This should succeed, because we have given a time
+	// that is well enough into the past
+	if !assert.NoError(t, c.Verify(jwt.WithClock(jwt.ClockFunc(func() time.Time { return tm.Add(-2*time.Hour) }))), "claimset.Verify should succeed") {
+		return
+	}
+}
+

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -77,19 +77,25 @@ func TestGHIssue10(t *testing.T) {
 		return
 	}
 
-	//Verify signature and grab payload
+	// Verify signature and grab payload
 	verified, err := jws.Verify(sbuf, jwa.RS256, &rsakey.PublicKey)
-	if !assert.Error(t, err, `jws.Verify should succeed`) {
+	if !assert.NoError(t, err, `jws.Verify should succeed`) {
+
+	}
+
+	// Verify claims
+	cs := jwt.NewClaimSet()
+	if err = cs.UnmarshalJSON(verified); err != nil {
+		t.Logf("failed to get claimset: %s", err)
+		return
+	}
+
+	if !assert.Error(t, cs.Verify(), "claimset.Verify should fail") {
 		t.Logf("JWS verified even expired!!!")
-		//get claimset
-		cs := jwt.NewClaimSet()
-		if err = cs.UnmarshalJSON(verified); err != nil {
-			t.Logf("failed to get claimset: %s", err)
-			return
-		}
 		// print Essential claims
 		t.Logf("IssuedAt: %v", time.Unix(cs.IssuedAt, 0))
 		t.Logf("Expiration: %v", time.Unix(cs.Expiration, 0))
 		t.Logf("NotBefore: %v", cs.NotBefore)
+		return
 	}
 }

--- a/jwt/verify.go
+++ b/jwt/verify.go
@@ -1,0 +1,85 @@
+package jwt
+
+import (
+	"errors"
+	"time"
+)
+
+const clockKey = "clock"
+const acceptableSkewKey = "acceptableSkew"
+
+type VerifyOption interface {
+	Name() string
+	Value() interface{}
+}
+
+type verifyOption struct {
+	name  string
+	value interface{}
+}
+
+func (o *verifyOption) Name() string {
+	return o.name
+}
+
+func (o *verifyOption) Value() interface{} {
+	return o.value
+}
+
+type Clock interface {
+	Now() time.Time
+}
+type ClockFunc func() time.Time
+
+func (f ClockFunc) Now() time.Time {
+	return f()
+}
+
+// WithClock specifies the `Clock` to be used when verifying
+// claims exp and nbf.
+func WithClock(c Clock) VerifyOption {
+	return &verifyOption{
+		name:  clockKey,
+		value: c,
+	}
+}
+
+// WithAcceptableSkew specifies the duration in which exp and nbf
+// claims may differ by. This value should be positive
+func WithAcceptableSkew(dur time.Duration) VerifyOption {
+	return &verifyOption{
+		name:  acceptableSkewKey,
+		value: dur,
+	}
+}
+
+// Verify makes sure that the essential claims stand.
+// See the various `WithXXX` functions for optional parameters
+// that can control the behavior of this method.
+func (c *ClaimSet) Verify(options ...VerifyOption) error {
+	var clock Clock = ClockFunc(time.Now)
+	var skew time.Duration
+	for _, o := range options {
+		switch o.Name() {
+		case clockKey:
+			clock = o.Value().(Clock)
+		case acceptableSkewKey:
+			skew = o.Value().(time.Duration)
+		}
+	}
+	// iss
+	// sub
+	// aud
+	// exp
+	// iat
+	// jti
+	// check for nbf
+	if t := c.NotBefore; t != nil {
+		now := clock.Now().Truncate(time.Second)
+		// now cannot be before t, so we check for now > t - skew
+		if !now.After(t.Time.Add(-1 * skew).Truncate(time.Second)) {
+			return errors.New(`nbf not satisfied`)
+		}
+	}
+	return nil
+}

--- a/jwt/verify.go
+++ b/jwt/verify.go
@@ -71,6 +71,14 @@ func (c *ClaimSet) Verify(options ...VerifyOption) error {
 	// sub
 	// aud
 	// exp
+	if tv := c.Expiration; tv > 0 {
+		t := time.Unix(tv, 0)
+		now := clock.Now().Truncate(time.Second)
+		if !now.Before(t.Add(skew)) {
+			return errors.New(`exp not satisfied`)
+		}
+	}
+
 	// iat
 	// jti
 	// check for nbf


### PR DESCRIPTION
new API, `jwt.Verify` verifies the some of the essential claims in the claim set.
nbf and exp are checked regardless. aud, iss, and sub are checked if `WithXXX` is given. For the time being I don't see how to "verify" iat and jti, so no check is done.

fixes #10