### PR TITLE
Fix bad trimming of compact JWS signatures.

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -353,7 +353,6 @@ func parseCompact(buf []byte) (*Message, error) {
 	if _, err := enc.Decode(signature, parts[2]); err != nil {
 		return nil, err
 	}
-	signature = bytes.TrimRight(signature, "\x00")
 
 	s := NewSignature()
 	s.Signature = signature

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -571,7 +571,7 @@ func TestDecode_ES384Compact_NoSigTrim(t *testing.T) {
     "y":"CRKSqP-aYTIsqJfg_wZEEYUayUR5JhZaS2m4NLk2t1DfXZgfApAJ2lBO0vWKnUMp"
   }`
 	msg, err := ParseString(incoming)
-	if !assert.NoError(t, err, "Parsing compact serialization with bad signature should be an error") {
+	if !assert.NoError(t, err, "Parsing compact serialization signature should succeed") {
 		return
 	}
 	pubkey, err := ecdsautil.PublicKeyFromJSON([]byte(jwksrc))

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -560,3 +560,30 @@ func TestPublicHeaders(t *testing.T) {
 		return
 	}
 }
+
+func TestDecode_ES384Compact_NoSigTrim(t *testing.T) {
+	incoming := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6IjE5MzFmZTQ0YmFhMWNhZTkyZWUzNzYzOTQ0MDU1OGMwODdlMTRlNjk5ZWU5NjVhM2Q1OGU1MmU2NGY4MDE0NWIifQ.eyJpc3MiOiJicmt0LWNsaS0xLjAuN3ByZTEiLCJpYXQiOjE0ODQ2OTU1MjAsImp0aSI6IjgxYjczY2Y3In0.DdFi0KmPHSv4PfIMGcWGMSRLmZsfRPQ3muLFW6Ly2HpiLFFQWZ0VEanyrFV263wjlp3udfedgw_vrBLz3XC8CkbvCo_xeHMzaTr_yfhjoheSj8gWRLwB-22rOnUX_M0A"
+	t.Logf("incoming = '%s'", incoming)
+	const jwksrc = `{
+    "kty":"EC",
+    "crv":"P-384",
+    "x":"YHVZ4gc1RDoqxKm4NzaN_Y1r7R7h3RM3JMteC478apSKUiLVb4UNytqWaLoE6ygH",
+    "y":"CRKSqP-aYTIsqJfg_wZEEYUayUR5JhZaS2m4NLk2t1DfXZgfApAJ2lBO0vWKnUMp"
+  }`
+	msg, err := ParseString(incoming)
+	if !assert.NoError(t, err, "Parsing compact serialization with bad signature should be an error") {
+		return
+	}
+	pubkey, err := ecdsautil.PublicKeyFromJSON([]byte(jwksrc))
+	if !assert.NoError(t, err, "parsing jwk should be successful") {
+		return
+	}
+	v, err := NewEcdsaVerify(jwa.ES384, pubkey)
+	if !assert.NoError(t, err, "EcdsaVerify created") {
+		return
+	}
+	if !assert.NoError(t, v.Verify(msg), "Verify succeeds") {
+		return
+	}
+}
+

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -13,7 +13,11 @@ func TestClaimSet(t *testing.T) {
 	c1 := jwt.NewClaimSet()
 	c1.Set("jti", "AbCdEfG")
 	c1.Set("sub", "foobar@example.com")
-	now := time.Now()
+
+	// Silly fix to remove monotonic element from time.Time obatained
+	// from time.Now(). Without this, the equality comparison goes
+	// ga-ga for golang tip (1.9)
+	now := time.Unix(time.Now().Unix(), 0)
 	c1.Set("iat", now)
 	c1.Set("nbf", now.Add(5*time.Second))
 	c1.Set("exp", now.Add(10*time.Second))


### PR DESCRIPTION
The decoding of compact form JWS tokens incorrectly performs a
TrimRight to strip trailing zero bytes from the token signature
after decoding from base64. It should not do this.

I found that about 1% of the JWS tokens we generated using
another tool were failing signature verification by go-jwx.
These JWS tokens were valid and correctly formatted and after
some spelunking into the go-jwx code we discovered this trim
of trailing zeroes from the compact signature was the problem.
This specifically fails when the generated signature (ECDSA
P-384 in this case) actually had a trailing zero byte in the
serialized S component of the signature.

This patch removes the offending TrimRight. A unit test has
also been added to verify one of the specific instances of
a failing JWS token from my testing. This trimming does not
appear to be done for JSON encoded JWS tokens.