### PR TITLE
Properly error out when certain KeyWrap / ContentEncrypt algorithms are used together

### DIFF
--- a/jwe/aescbc/aescbc.go
+++ b/jwe/aescbc/aescbc.go
@@ -7,12 +7,12 @@ import (
 	"crypto/sha512"
 	"crypto/subtle"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"hash"
 
 	"github.com/lestrrat/go-jwx/internal/debug"
 	"github.com/lestrrat/go-jwx/internal/padbuf"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -35,6 +35,7 @@ func New(key []byte, f BlockCipherFunc) (*AesCbcHmac, error) {
 	ekey := key[keysize:]
 
 	if debug.Enabled {
+		debug.Printf("New: keysize               = %d", keysize)
 		debug.Printf("New: cek (key)             = %x (%d)\n", key, len(key))
 		debug.Printf("New: ikey                  = %x (%d)\n", ikey, len(ikey))
 		debug.Printf("New: ekey                  = %x (%d)\n", ekey, len(ekey))
@@ -54,7 +55,7 @@ func New(key []byte, f BlockCipherFunc) (*AesCbcHmac, error) {
 	case 32:
 		hfunc = sha512.New
 	default:
-		return nil, errors.New("unsupported key size")
+		return nil, errors.Errorf("unsupported key size %d", keysize)
 	}
 
 	return &AesCbcHmac{

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -1,6 +1,9 @@
 package jwe
 
-import "github.com/lestrrat/go-jwx/internal/debug"
+import (
+	"github.com/lestrrat/go-jwx/internal/debug"
+	"github.com/pkg/errors"
+)
 
 // NewMultiEncrypt creates a new Encrypt struct. The caller is responsible
 // for instantiating valid inputs for ContentEncrypter, KeyGenerator,
@@ -47,7 +50,7 @@ func (e MultiEncrypt) Encrypt(plaintext []byte) (*Message, error) {
 			if debug.Enabled {
 				debug.Printf("Failed to encrypt key: %s", err)
 			}
-			return nil, err
+			return nil, errors.Wrap(err, `failed to encrypt key`)
 		}
 		r.EncryptedKey = enckey.Bytes()
 		if hp, ok := enckey.(HeaderPopulater); ok {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -57,7 +57,7 @@ func Encrypt(payload []byte, keyalg jwa.KeyEncryptionAlgorithm, key interface{},
 		switch aesKeySize := keysize / 2; aesKeySize {
 		case 16, 24, 32:
 		default:
-			return nil, errors.Errorf("unsupported keysize %d (from content encryption algorithm %s). consider using content encryption that uses smaller keys", aesKeySize, contentalg)
+			return nil, errors.Errorf("unsupported keysize %d (from content encryption algorithm %s). consider using content encryption that uses 32, 48, or 64 byte keys", keysize, contentalg)
 		}
 	case jwa.ECDH_ES_A128KW, jwa.ECDH_ES_A192KW, jwa.ECDH_ES_A256KW:
 		pubkey, ok := key.(*ecdsa.PublicKey)

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -6,12 +6,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/json"
-	"errors"
 
 	"github.com/lestrrat/go-jwx/buffer"
 	"github.com/lestrrat/go-jwx/internal/debug"
 	"github.com/lestrrat/go-jwx/jwa"
 	"github.com/lestrrat/go-jwx/jwk"
+	"github.com/pkg/errors"
 )
 
 // Encrypt takes the plaintext payload and encrypts it in JWE compact format.
@@ -54,6 +54,11 @@ func Encrypt(payload []byte, keyalg jwa.KeyEncryptionAlgorithm, key interface{},
 			return nil, err
 		}
 		keysize = contentcrypt.KeySize()
+		switch aesKeySize := keysize / 2; aesKeySize {
+		case 16, 24, 32:
+		default:
+			return nil, errors.Errorf("unsupported keysize %d (from content encryption algorithm %s). consider using content encryption that uses smaller keys", aesKeySize, contentalg)
+		}
 	case jwa.ECDH_ES_A128KW, jwa.ECDH_ES_A192KW, jwa.ECDH_ES_A256KW:
 		pubkey, ok := key.(*ecdsa.PublicKey)
 		if !ok {
@@ -77,6 +82,9 @@ func Encrypt(payload []byte, keyalg jwa.KeyEncryptionAlgorithm, key interface{},
 		return nil, ErrUnsupportedAlgorithm
 	}
 
+	if debug.Enabled {
+		debug.Printf("Encrypt: keysize = %d", keysize)
+	}
 	enc := NewMultiEncrypt(contentcrypt, NewRandomKeyGenerate(keysize), keyenc)
 	msg, err := enc.Encrypt(payload)
 	if err != nil {

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const examplePayload = `The true sign of intelligence is not knowledge but imagination.`
+const (
+	examplePayload = `The true sign of intelligence is not knowledge but imagination.`
+	a256kwKey      = "12345678901234567890123456789012"
+)
 
 var rsaPrivKey *rsa.PrivateKey
 
@@ -352,4 +355,9 @@ func TestEncode_ECDHES(t *testing.T) {
 		return
 	}
 	t.Logf("%s", decrypted)
+}
+
+func Test_A256KW_A256CBC_HS512(t *testing.T) {
+	_, err := Encrypt([]byte(examplePayload), jwa.A256KW, []byte(a256kwKey), jwa.A256CBC_HS512, jwa.NoCompress)
+	assert.NoError(t, err, "failed to encrypt payload")
 }

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	examplePayload = `The true sign of intelligence is not knowledge but imagination.`
-	a256kwKey      = "12345678901234567890123456789012"
 )
 
 var rsaPrivKey *rsa.PrivateKey
@@ -358,6 +357,13 @@ func TestEncode_ECDHES(t *testing.T) {
 }
 
 func Test_A256KW_A256CBC_HS512(t *testing.T) {
-	_, err := Encrypt([]byte(examplePayload), jwa.A256KW, []byte(a256kwKey), jwa.A256CBC_HS512, jwa.NoCompress)
-	assert.NoError(t, err, "failed to encrypt payload")
+	var keysize = 32
+	var key = make([]byte, keysize)
+	for i := 0; i < keysize; i++ {
+		key[i] = byte(i)
+	}
+	_, err := Encrypt([]byte(examplePayload), jwa.A256KW, key, jwa.A256CBC_HS512, jwa.NoCompress)
+	if !assert.Error(t, err, "should fail to encrypt payload") {
+		return
+	}
 }

--- a/jwe/key_encrypt.go
+++ b/jwe/key_encrypt.go
@@ -11,17 +11,17 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"hash"
 
 	"github.com/lestrrat/go-jwx/internal/concatkdf"
 	"github.com/lestrrat/go-jwx/internal/debug"
 	"github.com/lestrrat/go-jwx/jwa"
+	"github.com/pkg/errors"
 )
 
 // NewKeyWrapEncrypt creates a key-wrap encryptor using AES-CGM.
-// Althought the name suggests otherwise, this does decryption as well.
+// Although the name suggests otherwise, this does the decryption as well.
 func NewKeyWrapEncrypt(alg jwa.KeyEncryptionAlgorithm, sharedkey []byte) (KeyWrapEncrypt, error) {
 	return KeyWrapEncrypt{
 		alg:       alg,
@@ -57,11 +57,11 @@ func (kw KeyWrapEncrypt) KeyDecrypt(enckey []byte) ([]byte, error) {
 func (kw KeyWrapEncrypt) KeyEncrypt(cek []byte) (ByteSource, error) {
 	block, err := aes.NewCipher(kw.sharedkey)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, `keywrap: failed to create cipher`)
 	}
 	encrypted, err := keywrap(block, cek)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, `keywrap: failed to wrap the key`)
 	}
 	return ByteKey(encrypted), nil
 }


### PR DESCRIPTION
@Warashi has notified me that using `jwa.A256KW` and `jwa.A256CBC_HS512` together doesn't work. In fact, any of `jwa.A128KW`, `jwa.A192KW`, `jwa.A256KW` doesn't work with content encryption algorithms with key sizes not in the set 16, 24, or 32.

This PR makes changes to properly report that error.