### PR TITLE
Avoid comparing time structs directly because the time zone may be different

### DIFF
--- a/jwt/verify.go
+++ b/jwt/verify.go
@@ -139,7 +139,7 @@ func (t *Token) Verify(options ...Option) error {
 	if tv := t.issuedAt; tv != nil {
 		now := clock.Now().Truncate(time.Second)
 		ttv := tv.Time.Truncate(time.Second)
-		if now != ttv && !now.After(ttv.Add(-1 * skew)) {
+		if now.Before(ttv.Add(-1 * skew)) {
 			return errors.New(`iat not satisfied`)
 		}
 	}


### PR DESCRIPTION
Time struct derived from deserialised json epoch is in UTC, time.Now() is local time.